### PR TITLE
Adjust sarama config

### DIFF
--- a/beater/kafkabeat.go
+++ b/beater/kafkabeat.go
@@ -32,8 +32,8 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 	kafkaConfig.Group.Return.Notifications = true
 	kafkaConfig.Config.ClientID = "kafkabeat"
 	kafkaConfig.Config.Consumer.Offsets.Initial = sarama.OffsetOldest
-	kafkaConfig.Config.Consumer.MaxWaitTime = 500 *time.Millisecond
-	kafkaConfig.Config.Consumer.MaxProcessingTime = 5000 *time.Millisecond
+	kafkaConfig.Config.Consumer.MaxWaitTime = 500 * time.Millisecond
+	kafkaConfig.Config.Consumer.MaxProcessingTime = 5000 * time.Millisecond
 
 	consumer, err := cluster.NewConsumer(config.Brokers, config.Group, config.Topics, kafkaConfig)
 	if err != nil {

--- a/beater/kafkabeat.go
+++ b/beater/kafkabeat.go
@@ -30,7 +30,10 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 	kafkaConfig := cluster.NewConfig()
 	kafkaConfig.Consumer.Return.Errors = true
 	kafkaConfig.Group.Return.Notifications = true
+	kafkaConfig.Config.ClientID = "kafkabeat"
 	kafkaConfig.Config.Consumer.Offsets.Initial = sarama.OffsetOldest
+	kafkaConfig.Config.Consumer.MaxWaitTime = 500 *time.Millisecond
+	kafkaConfig.Config.Consumer.MaxProcessingTime = 5000 *time.Millisecond
 
 	consumer, err := cluster.NewConsumer(config.Brokers, config.Group, config.Topics, kafkaConfig)
 	if err != nil {


### PR DESCRIPTION
* set ClientId to "kafkabeat" to remove sarama log message
  "ClientID is the default of 'sarama', you should consider
  setting it to something application-specific."
* Increase max times for consuming kafka message by setting
    kafkaConfig.Config.Consumer.MaxWaitTime = 500 *time.Millisecond
    kafkaConfig.Config.Consumer.MaxProcessingTime = 5000 *time.Millisecond
  Reason: Consuming messages took too long for default values on our systems.

Change-Id: If6701799287837aad5e366d9b6d689577a1a5640